### PR TITLE
Blacklist composer/xdebug-handler:1.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Runs a php script with XDebug disabled",
     "keywords" : ["Xdebug", "xdebug", "performance"],
     "require": {
-        "composer/xdebug-handler": "^1.0",
+        "composer/xdebug-handler": "1.0.0 || >= 1.2",
         "php": "~5.3 || ~7.0"
     },
     "require-dev": {


### PR DESCRIPTION
1.1.0 broke handling of the code on standard input (which is required for phpunit)