### PR TITLE
Disable xdebug for whole process tree

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Runs a php script with XDebug disabled",
     "keywords" : ["Xdebug", "xdebug", "performance"],
     "require": {
-        "composer/xdebug-handler": "^1.1.0",
+        "composer/xdebug-handler": "^1.2",
         "php": "~5.3 || ~7.0"
     },
     "require-dev": {

--- a/src/prepend.php
+++ b/src/prepend.php
@@ -1,5 +1,6 @@
 <?php
 namespace Weirdan\RunWithoutXdebug;
+
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     // standalone
     require __DIR__ . '/../vendor/autoload.php';
@@ -28,4 +29,6 @@ call_user_func(function() {
 
     $x->setLogger($logger);
     $x->check();
+    $config = new \Composer\XdebugHandler\PhpConfig;
+    $config->usePersistent();
 });


### PR DESCRIPTION
This fixes issue with phpunit failing to disable xdebug when process isolation was in effect