### PR TITLE
Update xdebug-handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Runs a php script with XDebug disabled",
     "keywords" : ["Xdebug", "xdebug", "performance"],
     "require": {
-        "composer/xdebug-handler": "^1.2",
+        "composer/xdebug-handler": "^1.3",
         "php": "~5.3 || ~7.0"
     },
     "require-dev": {

--- a/src/prepend.php
+++ b/src/prepend.php
@@ -44,10 +44,8 @@ call_user_func(function() {
     $logger->debug('argv[0]: ' . $_SERVER['argv'][0]);
     $logger->debug('Main script: ' . $mainScript);
 
-    $x->setMainScript($mainScript);
-
-    $x->setLogger($logger);
-    $x->check();
-    $config = new \Composer\XdebugHandler\PhpConfig;
-    $config->usePersistent();
+    $x->setMainScript($mainScript)
+        ->setLogger($logger)
+        ->setPersistent()
+        ->check();
 });


### PR DESCRIPTION
Release 1.3.0 makes it easy to keep xdebug out of PHP sub-processes.