### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,11 @@
         "php": "~5.6 || ~7.0",
         "squizlabs/php_codesniffer": "^3.3"
     },
+    "autoload": {
+        "psr-4": {
+            "Weirdan\\RunWithoutXdebug\\": "src"
+        }
+    },
     "autoload-dev": {
         "psr-4": {
             "Weirdan\\RunWithoutXdebug\\Tests\\Integration\\" : "tests/integration"


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test becasue this version is stable now.
- Defining the `autoload` block inside `composer.json` to load the `Weirdan\RunWithoutXdebug` class namespace automatically.