### PR TITLE
Quote individual arguments when passing them down the line

### DIFF
--- a/bin/php-noxdebug
+++ b/bin/php-noxdebug
@@ -1,3 +1,3 @@
 #!/bin/sh
 PREPEND=$(readlink -f -- "$(dirname $(readlink -f -- $0))/../src/prepend.php")
-exec php -d"auto_prepend_file=$PREPEND" $*
+exec php -d"auto_prepend_file=$PREPEND" "$@"


### PR DESCRIPTION
If a command-line argument has whitespaces, the wrapper splits it into multiple arguments:
```
$ php-noxdebug vendor/bin/phpunit "My Test.php"
PHPUnit 9.1.4 by Sebastian Bergmann and contributors.

Cannot open file "My".
```
